### PR TITLE
chore: add chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,14 @@
+# .github/workflows/chromatic.yml
+name: "Chromatic"
+on: push
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,7 +8,11 @@ jobs:
       - uses: actions/checkout@v1
       - name: Install dependencies
         run: yarn
+        working-directory: ./lib
       - name: Publish to Chromatic
         uses: chromaui/action@v1
+        # working-directory: ./lib
         with:
+          # storybookBaseDir: ./lib
+          workingDir: ./lib
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/lib/package.json
+++ b/lib/package.json
@@ -21,6 +21,8 @@
     "@storybook/vue-vite": "^7.5.1",
     "@vitejs/plugin-vue": "^4.2.3",
     "storybook": "^7.5.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "vite": "^4.4.5",
     "vite-plugin-vue2": "^2.0.3",
     "vue": "2.7.14",


### PR DESCRIPTION
akcja aktumatycznie buduje projekt i deployuje na chromatic

taki link można np. przekleić do opisu repo, by każdy mógł wygodnie zobaczyć jak obecnie wygląda projekt


https://github.com/chromaui/action 

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsworking-directory